### PR TITLE
Fixed _onKeyPressed crashing on windows 11 with flutter 2.5

### DIFF
--- a/lib/src/dropdown.dart
+++ b/lib/src/dropdown.dart
@@ -1,9 +1,8 @@
 import 'dart:async';
 
+import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
-
-import 'package:flutter/foundation.dart';
 
 class DropdownEditingController<T> extends ChangeNotifier {
   T? _value;
@@ -129,7 +128,7 @@ class DropdownFormFieldState<T> extends State<DropdownFormField>
   DropdownEditingController<dynamic>? get _effectiveController =>
       widget.controller ?? _controller;
 
-  DropdownFormFieldState() : super() {}
+  DropdownFormFieldState() : super();
 
   @override
   void initState() {
@@ -366,7 +365,7 @@ class DropdownFormFieldState<T> extends State<DropdownFormField>
     });
   }
 
-  _onKeyPressed(RawKeyEvent event) {
+  KeyEventResult _onKeyPressed(RawKeyEvent event) {
     // print('_onKeyPressed : ${event.character}');
     if (event.isKeyPressed(LogicalKeyboardKey.enter)) {
       if (_searchFocusNode.hasFocus) {
@@ -374,26 +373,26 @@ class DropdownFormFieldState<T> extends State<DropdownFormField>
       } else {
         _toggleOverlay();
       }
-      return false;
+      return KeyEventResult.skipRemainingHandlers;
     } else if (event.isKeyPressed(LogicalKeyboardKey.escape)) {
       _removeOverlay();
-      return true;
+      return KeyEventResult.handled;
     } else if (event.isKeyPressed(LogicalKeyboardKey.arrowDown)) {
       int v = _listItemFocusedPosition;
       v++;
       if (v >= _options!.length) v = 0;
       _listItemFocusedPosition = v;
       _listItemsValueNotifier.value = List<T>.from(_options ?? []);
-      return true;
+      return KeyEventResult.handled;
     } else if (event.isKeyPressed(LogicalKeyboardKey.arrowUp)) {
       int v = _listItemFocusedPosition;
       v--;
       if (v < 0) v = _options!.length - 1;
       _listItemFocusedPosition = v;
       _listItemsValueNotifier.value = List<T>.from(_options ?? []);
-      return true;
+      return KeyEventResult.handled;
     }
-    return false;
+    return KeyEventResult.ignored;
   }
 
   _search(String str) async {


### PR DESCRIPTION
Windows 11 crashes, saying there is no physical keyboard detected. Unsure whether flutter 2.5 affected other platforms as well. It should be fine though as onKey from Focus does expect return type  KeyEventResult.